### PR TITLE
Added new subsets method

### DIFF
--- a/src/subsets.jl
+++ b/src/subsets.jl
@@ -285,12 +285,15 @@ end
 """
     subsets(s::Union{SmallBitSet, AbstractSmallSet}, k::Integer)
     subsets(n::Integer, k::Integer)
+    subsets(s::Union{AbstractFixedOrSmallOrPackedVector, AbstractSmallSet})
 
 In the first form, return an iterator that yields all `k`-element subsets of the set `s`.
 The element type of the iterator is a `SmallBitSet` or `SmallSet`.
 If `k` is negative or larger than `length(s)`, then the iterator is empty.
 
 In the second form the set `s` is taken to be `SmallBitSet(1:n)`.
+
+In the third form, return an iterator that yeilds all subsets of the set `s`.
 
 See also [`subsets(::Integer)`](@ref),
 [`combinations`](@ref combinations(::Integer, ::Integer)),
@@ -342,6 +345,9 @@ eltype(::Type{Subsets2Int}) = SmallBitSet{UInt}
 eltype(::Type{Subsets2{S}}) where S <: SmallBitSet = S
 
 subsets(s::AbstractSmallSet, k::Integer) = combinations(s, k)
+
+subsets(c::Union{AbstractFixedOrSmallOrPackedVector, AbstractSmallSet}) =
+    Generator(Fix1(_inbounds_getindex, c), subsets(length(c)))
 
 # combinations
 


### PR DESCRIPTION
This PR adds the ability to generate all possible subsets for types beyond `SmallBitSet`. 

As a user I was originally defining `subsets(s::AbstractSmallSet) = Iterators.Flatten(subsets(s,i) for i in 0:length(s))`, which is about twice as slow as this PR.

As I was adding this I realized why it probably wasn't included at first. `subsets(s::S) where S <: SmallBitSet` returns a `SmallCombinatorics.Subsets` vector whereas `subsets(c::Union{AbstractFixedOrSmallOrPackedVector, AbstractSmallSet})` returns an iterator, which could be confusing. However, it is convenient to have a function that will iterate over all possible subsets for all types in SmallCollections.

